### PR TITLE
issue#12 Updated the workflow to match the one for submission service

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,26 +12,10 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/comment
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - name: Get new version
-        id: version_tag
-        uses: anothrNick/github-tag-action@8c8163ef62cf9c4677c8e800f36270af27930f42 # 1.61.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_CONTEXT: branch
-          PRERELEASE: ${{ github.ref != 'refs/heads/main' }}
-  
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up NodeJS
         uses: actions/setup-node@v3
         with:
@@ -41,53 +25,94 @@ jobs:
       - name: Run tests
         run: npm test
 
+  version:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    permissions:
+      contents: write
+    outputs:
+      version_resolved: ${{ steps.resolve_version.outputs.version_resolved }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: Tag and use it as version
+        if: github.ref == 'refs/heads/main'
+        uses: anothrNick/github-tag-action@8c8163ef62cf9c4677c8e800f36270af27930f42 # 1.61.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_CONTEXT: branch
+          PRERELEASE: ${{ github.ref != 'refs/heads/main' }}
+
+      - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1.6.0
+        id: version_latest_tag
+        if: github.ref == 'refs/heads/main'
+
+      - name: Use branch name as version
+        if: github.ref != 'refs/heads/main'
+        id: version_branch_name
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          echo "Branch name: $BRANCH_NAME"
+          echo "branch_name=${BRANCH_NAME//\//_}" >> $GITHUB_OUTPUT
+      
+      - name: Output resolved version
+        id: resolve_version
+        run: |
+          if [ -n "${{ steps.version_latest_tag.outputs.tag }}" ]; then
+            echo "version_resolved=${{ steps.version_latest_tag.outputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "version_resolved=${{ steps.version_branch_name.outputs.branch_name }}" >> $GITHUB_OUTPUT
+          fi
+
   build:
     needs:
       - version
-      - test
     permissions:
       packages: write
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1.6.0
-      id: latest_tag
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    - name: Build and push image tag ${{steps.latest_tag.outputs.tag}}
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        labels: ${{ steps.meta.outputs.labels }}
-        tags: |
-          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{steps.latest_tag.outputs.tag}}
+      - name: Build and push image tag ${{ needs.version.outputs.version_resolved }}
+        env:
+          RESOLVED_VERSION: ${{needs.version.outputs.version_resolved}}
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.DOCKER_BUILD_CONTEXT }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RESOLVED_VERSION }}
 
-    - name: Build and push 'latest' tag
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: ${{ github.ref == 'refs/heads/main' }}
-        labels: ${{ steps.meta.outputs.labels }}
-        tags: |
-          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      - name: Build and push 'latest' tag
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.DOCKER_BUILD_CONTEXT }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.ref == 'refs/heads/main' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
Closes #12 

Updated the workflow
  - `test` job to be executed first - that way we are not pushing a tag if the changes are failing the quality gates. 
  - `version` job to resolve a "version" to use as a Docker image tag - should create a semver tag if executed on `main`, use current branch name otherwise, dependent on `test` job successful execution
  - `build` job - publishes image with version resolved in the `version` job & 'latest" if on main
